### PR TITLE
Allow to specify a RAID as explicit boot device

### DIFF
--- a/service/lib/agama/storage/config.rb
+++ b/service/lib/agama/storage/config.rb
@@ -64,7 +64,7 @@ module Agama
       def boot_device
         return unless boot.configure? && boot.device.device_alias
 
-        drives.find { |d| d.alias?(boot.device.device_alias) }
+        supporting_partitions.find { |d| d.alias?(boot.device.device_alias) }
       end
 
       # Drive config containing root.

--- a/service/lib/agama/storage/config_checkers/boot.rb
+++ b/service/lib/agama/storage/config_checkers/boot.rb
@@ -92,7 +92,7 @@ module Agama
         def valid_alias?
           return false unless device_alias
 
-          storage_config.drives.any? { |d| d.alias?(device_alias) }
+          storage_config.supporting_partitions.any? { |d| d.alias?(device_alias) }
         end
       end
     end

--- a/service/test/agama/storage/config_checkers/boot_test.rb
+++ b/service/test/agama/storage/config_checkers/boot_test.rb
@@ -29,17 +29,20 @@ describe Agama::Storage::ConfigCheckers::Boot do
 
   let(:config_json) do
     {
-      boot:   {
+      boot:    {
         configure: configure,
         device:    device_alias
       },
-      drives: [
+      drives:  [
         {
           alias:      "disk",
           partitions: [
             { alias: "p1" }
           ]
         }
+      ],
+      mdRaids: [
+        { alias: "raid" }
       ]
     }
   end
@@ -77,9 +80,12 @@ describe Agama::Storage::ConfigCheckers::Boot do
         include_examples "alias issue"
       end
 
-      context "and the device with the given alias is not a drive" do
-        let(:device_alias) { "p1" }
-        include_examples "alias issue"
+      context "and the device with the given alias is an mdRaid" do
+        let(:device_alias) { "raid" }
+
+        it "does not include any issue" do
+          expect(subject.issues).to be_empty
+        end
       end
 
       context "and the device with the given alias is a drive" do
@@ -88,6 +94,11 @@ describe Agama::Storage::ConfigCheckers::Boot do
         it "does not include any issue" do
           expect(subject.issues).to be_empty
         end
+      end
+
+      context "and the device with the given alias is neither a drive or an mdRaid" do
+        let(:device_alias) { "p1" }
+        include_examples "alias issue"
       end
     end
 

--- a/service/test/agama/storage/config_test.rb
+++ b/service/test/agama/storage/config_test.rb
@@ -54,17 +54,20 @@ describe Agama::Storage::Config do
     context "if boot config is set to be configured" do
       let(:config_json) do
         {
-          boot:   {
+          boot:    {
             configure: true,
             device:    device_alias
           },
-          drives: [
+          drives:  [
             {
               alias:      "disk1",
               partitions: [
                 { alias: "part1" }
               ]
             }
+          ],
+          mdRaids: [
+            { alias: "raid1" }
           ]
         }
       end
@@ -78,20 +81,29 @@ describe Agama::Storage::Config do
       end
 
       context "and boot config has a device alias" do
-        context "and there is not a drive config with the boot device alias" do
-          let(:device_alias) { "part1" }
-
-          it "returns nil" do
-            expect(subject.boot_device).to be_nil
-          end
-        end
-
         context "and there is a drive config with the boot device alias" do
           let(:device_alias) { "disk1" }
 
           it "returns the drive config" do
             expect(subject.boot_device).to be_a(Agama::Storage::Configs::Drive)
             expect(subject.boot_device.alias).to eq("disk1")
+          end
+        end
+
+        context "and there is an mdRaid config with the boot device alias" do
+          let(:device_alias) { "raid1" }
+
+          it "returns the mdRaid config" do
+            expect(subject.boot_device).to be_a(Agama::Storage::Configs::MdRaid)
+            expect(subject.boot_device.alias).to eq("raid1")
+          end
+        end
+
+        context "and there is not a drive or mdRaid config with the boot device alias" do
+          let(:device_alias) { "part1" }
+
+          it "returns nil" do
+            expect(subject.boot_device).to be_nil
           end
         end
       end


### PR DESCRIPTION
## Problem

Right now a configuration error is reported if `storage.boot.device` points to an entry at `mdRaids`. 

A configuration like this:

```json
{
  "storage":  {
    "mdRaids": [
        {
           "search":     { "max": 1 },
           "alias":      "raid",
           "partitions": [
              { "search": "*", "delete": true },
              { "filesystem": { "path": "/" } }
           ]
         }
    ],
    "boot":    { "configure": true, "device": "raid" }
  }
}
```

...resulted in the error "_There is no boot device with alias 'raid'_".

## Solution

Honor the mentioned setting if the mdRaid entry corresponds to a pre-existing RAID device. Since the configuration is explicit, is the user responsibility to choose a RAID that actually boots.

## Testing

- Extended unit tests for the configuration
- Added a new unit test for the proposal that proves it really does the job if the RAID exists beforehand.

## Not working

If the entry at `mdRaids` corresponds to a new RAID that will be created during the proposal, then the configuration will be accepted but the proposal will not use the new RAID to allocate the boot partitions. That's kind of expected given the nature of the proposal.